### PR TITLE
Update smartmontools' supported device list URL

### DIFF
--- a/README
+++ b/README
@@ -8,7 +8,7 @@ driver, so most existing applications should work.
 
 The driver requires a SAT (SCSI ATA Translation) capable external
 drive enclosure. Check smartmontools list for supported devices:
-http://sourceforge.net/apps/trac/smartmontools/wiki/Supported_USB-Devices 
+http://smartmontools.org/wiki/Supported_USB-Devices 
 If the Option column contains sat or jmicron, the driver should work.
 The driver should work with Snow Leopard and Lion and Mountain Lion. 
 People have reported problems with Lion and Encrypted volumes. 


### PR DESCRIPTION
Fix broken URL.  

http://www.smartmontools.org    says:   2014-06-05: As sourceforge will retire Trac as hosted app, we moved our wiki and ticket tracker to this server. Many thanks to Alex Samorukov who made this possible! :-)
